### PR TITLE
travis: fix erlang issues in osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ install:
 
          for pkg in $OSX_PACKAGES; do
            [[ "$(brew ls --versions $pkg)" ]] || brew install --force-bottle $pkg
-           brew outdated $pkg || brew upgrade --force-bottle $pkg
          done
      fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: generic
 matrix:
   include:
     - os: osx
+      osx_image: xcode8
       env:
         - OSX_PACKAGES="boost erlang python python3 ant bash coreutils"
     - os: linux


### PR DESCRIPTION
Erlang was rebuilt from source in osx 10.9. bumping version to 10.11